### PR TITLE
Optimize display menu's check for index_html

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ New:
 
 Fixes:
 
-- *add item here*
+- Optimized display menu's check for `index_html`.
+  [davisagli]
 
 
 2.1.7 (2016-02-19)

--- a/plone/app/contentmenu/menu.py
+++ b/plone/app/contentmenu/menu.py
@@ -215,7 +215,7 @@ class DisplaySubMenuItem(BrowserSubMenuItem):
             context = utils.parent(context)
         if not getattr(context, 'isPrincipiaFolderish', False):
             return False
-        elif 'index_html' not in context.objectIds():
+        elif 'index_html' not in context:
             return False
         else:
             return True


### PR DESCRIPTION
This makes a big difference for BTree-based folders with thousands of items when the container is not yet in the ZODB cache. `context.objectIds()` woke all BTree buckets and built a list of ids
whereas `'index_html' in context` just does a BTree lookup.