### PR TITLE
fix state icon position in toolbar when no permission

### DIFF
--- a/news/29.bugfix
+++ b/news/29.bugfix
@@ -1,0 +1,3 @@
+Fix review state icon position in toolbar when the user doesn't have the permission to change the review state.
+This fixes https://github.com/plone/plonetheme.barceloneta/issues/110
+[vincentfretin]

--- a/plone/app/contentmenu/contentmenu.pt
+++ b/plone/app/contentmenu/contentmenu.pt
@@ -10,12 +10,13 @@
       <a
           href="#"
           i18n:attributes="title;"
-          tal:attributes="href menuItem/action;
+          tal:attributes="href python:menuItem['action'] or 'javascript:void(0)';
+                          style python:not menuItem['action'] and 'cursor: default;; pointer-events: none' or None;
                           title menuItem/description;
                           class string:label-${state_class}"
           tal:define="state_class menuItem/extra/class | nothing;
                       state_class python:state_class and state_class or ''"
-          tal:omit-tag="not:menuItem/action">
+          >
         <span
             aria-hidden="true"
             class=""


### PR DESCRIPTION
Fix review state icon position in toolbar when the user doesn't have the permission to change the review state.

This fixes https://github.com/plone/plonetheme.barceloneta/issues/110
The fix is similar to https://github.com/plone/plonetheme.barceloneta/issues/110#issuecomment-316673559
that's it still keep the `<a>` tag but make it inactive. I also tried the css solution but gave up.

Before:
![Capture d’écran de 2020-07-08 15-58-46](https://user-images.githubusercontent.com/112249/86927699-f1a77d80-c133-11ea-8e5a-78aad8085acf.png)

After:
![Capture d’écran de 2020-07-08 15-59-21](https://user-images.githubusercontent.com/112249/86927751-0421b700-c134-11ea-8552-d07d8411a2e2.png)
Note that we have the state color now.