### PR TITLE
Change linktarget of workflow policies menu item

### DIFF
--- a/news/41.bugfix
+++ b/news/41.bugfix
@@ -1,0 +1,2 @@
+adjust workflow policies link target
+[1letter]

--- a/plone/app/contentmenu/menu.py
+++ b/plone/app/contentmenu/menu.py
@@ -910,7 +910,7 @@ class WorkflowMenu(BrowserMenu):
                     {
                         "title": _("workflow_policy", default="Policy..."),
                         "description": "",
-                        "action": url + "/placeful_workflow_configuration",
+                        "action": url + "/workflow-policies-controlpanel",
                         "selected": False,
                         "icon": None,
                         "extra": {

--- a/plone/app/contentmenu/menu.py
+++ b/plone/app/contentmenu/menu.py
@@ -910,7 +910,7 @@ class WorkflowMenu(BrowserMenu):
                     {
                         "title": _("workflow_policy", default="Policy..."),
                         "description": "",
-                        "action": url + "/workflow-policies-controlpanel",
+                        "action": url + "/@@placeful-workflow-configuration",
                         "selected": False,
                         "icon": None,
                         "extra": {


### PR DESCRIPTION
this should only be merged, if https://github.com/plone/Products.CMFPlacefulWorkflow/pull/42 is merged.

in this pr the linktarget of workflow policies menu item is renamed. it's more consistent if we `useworkflow-policies-controlpanel` instead of `placeful_workflow_configuration`