### PR TITLE
Actions menu description

### DIFF
--- a/news/24.bugfix
+++ b/news/24.bugfix
@@ -1,0 +1,2 @@
+Actions menu description - why leave blank?
+https://github.com/plone/plone.app.contentmenu/issues/24

--- a/news/24.bugfix
+++ b/news/24.bugfix
@@ -1,2 +1,2 @@
-Actions menu description - why leave blank?
-https://github.com/plone/plone.app.contentmenu/issues/24
+Add description to actions' menu items
+[kshitiz305]

--- a/plone/app/contentmenu/menu.py
+++ b/plone/app/contentmenu/menu.py
@@ -113,7 +113,7 @@ class ActionsMenu(BrowserMenu):
             results.append(
                 {
                     "title": action["title"],
-                    "description": action.get("description"),
+                    "description": action.get("description",""),
                     "action": addTokenToUrl(action["url"], request),
                     "selected": False,
                     "icon": icon,

--- a/plone/app/contentmenu/menu.py
+++ b/plone/app/contentmenu/menu.py
@@ -113,7 +113,7 @@ class ActionsMenu(BrowserMenu):
             results.append(
                 {
                     "title": action["title"],
-                    "description": action.get("description",""),
+                    "description": action.get("description", ""),
                     "action": addTokenToUrl(action["url"], request),
                     "selected": False,
                     "icon": icon,

--- a/plone/app/contentmenu/menu.py
+++ b/plone/app/contentmenu/menu.py
@@ -113,7 +113,7 @@ class ActionsMenu(BrowserMenu):
             results.append(
                 {
                     "title": action["title"],
-                    "description": "",
+                    "description": action.get("description"),
                     "action": addTokenToUrl(action["url"], request),
                     "selected": False,
                     "icon": icon,


### PR DESCRIPTION
It then passes an action with this empty description to the template, where it becomes an empty title attribute.

Closes #24 