### PR TITLE
Make `content_status_history` modal larger

### DIFF
--- a/news/67.bugfix
+++ b/news/67.bugfix
@@ -1,0 +1,2 @@
+Wider ``content_status_history`` modal.
+[petschki]

--- a/plone/app/contentmenu/menu.py
+++ b/plone/app/contentmenu/menu.py
@@ -893,6 +893,11 @@ class WorkflowMenu(BrowserMenu):
                         "id": "workflow-transition-advanced",
                         "separator": "actionSeparator",
                         "class": "pat-plone-modal",
+                        "modal": json.dumps(
+                            {
+                                "modalSizeClass": "modal-xl",
+                            }
+                        ),
                     },
                     "submenu": None,
                 }


### PR DESCRIPTION
Came across this while updateing the template here https://github.com/plone/plone.app.content/pull/285